### PR TITLE
Add Orfox support for mobile users

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "id": "id1-BoFifL9Vbdl2zQ@jetpack",
   "engines": {
     "firefox": ">=38.0a1",
-    "fennec": ">=38.0a1"
+    "fennec": ">=38.0"
   }
 }


### PR DESCRIPTION
With version 38.0 instead of 38.0a1 the add-on is compatible with [Orfox](https://github.com/guardianproject/tor-browser) (Fennec + Tor for Android).