### PR TITLE
Add preference to allow hiding release notes on upgrade/install

### DIFF
--- a/defaults/preferences/prefs.js
+++ b/defaults/preferences/prefs.js
@@ -2,3 +2,4 @@ pref('extensions.jid1-BoFifL9Vbdl2zQ@jetpack.addNotice', true);
 pref('extensions.jid1-BoFifL9Vbdl2zQ@jetpack.blockMissing', false);
 pref('extensions.jid1-BoFifL9Vbdl2zQ@jetpack.domainWhitelist', '');
 pref('extensions.jid1-BoFifL9Vbdl2zQ@jetpack.amountInjected', 0);
+pref('extensions.jid1-BoFifL9Vbdl2zQ@jetpack.showReleaseNotes', true);

--- a/lib/main.js
+++ b/lib/main.js
@@ -33,7 +33,7 @@ exports.main = function (options) {
     // Initialize add-on state.
     interceptor.register();
 
-    if (options.loadReason === 'install' || options.loadReason === 'upgrade') {
+    if (preferences.showReleaseNotes && (options.loadReason === 'install' || options.loadReason === 'upgrade')) {
 
         if (preferences['sdk.baseURI']) {
             tabs.open(preferences['sdk.baseURI'] + 'static/release-notes.html');


### PR DESCRIPTION
This can be useful for development testing, mass deployment (where you don't want to bother people on update), or just because you find it annoying that new tabs open when you update your add-ons!  :smiley: 