### PR TITLE
Implement support for Pale Moon v27.1 and higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "engines": {
     "firefox": ">=38.0a1",
     "fennec": ">=38.0a1",
-    "seamonkey": ">=2.0a1 <=2.46"
+    "seamonkey": ">=2.0a1 <=2.46",
+    "{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}": ">=27.1.0b1"
   }
 }


### PR DESCRIPTION
Based on [PMkit documentation draft v1.1](https://github.com/JustOff/pm27-sdk-addons/blob/master/PMkit.md), tested with [Pale Moon 27.1.0b1](http://www.palemoon.org/unstable/).

Resolves #119.