### PR TITLE
Support USTC Google Hosted Libraries mirror

### DIFF
--- a/core/mappings.js
+++ b/core/mappings.js
@@ -237,3 +237,6 @@ var mappings = {
         }
     }
 };
+
+// Mirror
+mappings['ajax.proxy.ustclug.org'] = mappings['ajax.googleapis.com'];


### PR DESCRIPTION
ajax.proxy.ustclug.org is a reversed proxy for ajax.googleapis.com. It is provided by USTC (a Chinese university) and is a commonly used mirror in China.

See also: issue #103 