### PR TITLE
Fix #202 by allowing variable popup widths

### DIFF
--- a/pages/popup/popup.css
+++ b/pages/popup/popup.css
@@ -11,7 +11,7 @@ body {
     margin: 0 auto;
     overflow: hidden;
     padding: 0;
-    width: 348px;
+    max-width: 348px;
 }
 
 header {


### PR DESCRIPTION
Popup width is fixed to 320px when the extension is pinned to overflow menu. The fixed width might change in the future, but the popup is responsive so we're only setting a max-width rather than a fixed width.