### PR TITLE
Increase text contrast

### DIFF
--- a/pages/popup/popup.css
+++ b/pages/popup/popup.css
@@ -181,7 +181,6 @@ footer {
 */
 
 .link-text {
-    color: #bdbdbd;
     cursor: pointer;
     float: left;
     font-size: 13px;
@@ -234,7 +233,6 @@ footer {
 }
 
 .label-domain {
-    color: #bbb;
     display: flex;
     font-style: italic;
     overflow: hidden;


### PR DESCRIPTION
Improves legibility and accessibility for people with cheap or badly calibrated displays, poor eyesight, low lighting conditions, lazy-readers, etc.

P.S.: Whenever you’re making a design with text that is hard to see, then reconsider whether the text needs to be there at all. It’s better to strip out such labels entirely if it’s [i]not that important[/i], as people will struggle to read it to be sure they’re not missing out on anything important.