### PR TITLE
Hide web accessible resources from websites

### DIFF
--- a/core/interceptor.js
+++ b/core/interceptor.js
@@ -111,7 +111,7 @@ interceptor._handleMissingCandidate = function (requestUrl) {
         requestUrl = requestUrlSegments.toString();
 
         return {
-            'redirectUrl': requestUrl
+            'redirectUrl': requestUrl + interceptor.warSecret
         };
 
     } else {
@@ -147,3 +147,22 @@ chrome.storage.local.get([Setting.AMOUNT_INJECTED, Setting.BLOCK_MISSING], funct
  */
 
 chrome.storage.onChanged.addListener(interceptor._handleStorageChanged);
+
+/**
+ * Guard web accessible resources from direct access by web pages
+ */
+
+interceptor.warSecret = '?_=' +
+    Math.floor(Math.random() * 982451653 + 982451653).toString(36) +
+    Math.floor(Math.random() * 982451653 + 982451653).toString(36);
+
+chrome.webRequest.onBeforeRequest.addListener(
+    function(requestDetails) {
+
+        if (!requestDetails.url.endsWith(interceptor.warSecret)) {
+            return { redirectUrl: chrome.runtime.getURL('/') };
+        }
+    },
+    {'urls': [chrome.runtime.getURL('/') + 'resources/*']},
+    [WebRequest.BLOCKING]
+);


### PR DESCRIPTION
With Chromium-based browsers, web pages can access directly
Decentraleyes' web accessible resources, and thus detect
whether Decentraleyes is used by a visitor.

This potentially adds one bit of information to fingerprinting.

See: "Discovering Browser Extensions via Web Accessible Resources"
www.cse.chalmers.se/~andrei/codaspy17.pdf

Proof-of-concept: https://jsfiddle.net/fuqrudcs/

The change here is to use a secret when accessing a web accessible
resource. If the secret is not present when the resource is fetched
by the browser, the behavior will be the same as if the resource
is not web accessible.

When Decentraleyes redirects a request to one of its web
accessible resources, the secret is appended at the end of the
local URL as a query parameter.

The secret is generated at runtime when Decentraleyes is launched.