### PR TITLE
Display injection counts in mobile menu entry titles

### DIFF
--- a/core/state-manager.js
+++ b/core/state-manager.js
@@ -44,6 +44,14 @@ stateManager.registerInjection = function (tabIdentifier, injection) {
         }
     }
 
+    if (injectionCount > 0) {
+        let title = 'Decentraleyes (' + injectionCount.toString() + ')'; 
+        wrappers.setTitle({
+            'title': title, 
+            'tabId': tabIdentifier
+        });
+    }
+
     if (isNaN(interceptor.amountInjected)) {
 
         chrome.storage.local.get(Setting.AMOUNT_INJECTED, function (items) {

--- a/modules/internal/wrappers.js
+++ b/modules/internal/wrappers.js
@@ -36,3 +36,13 @@ wrappers.setBadgeText = function (details) {
         chrome.browserAction.setBadgeText(details);
     }
 };
+
+// In firefox android, browser action shows as a menu entry instead of icon.
+// Use the below 'setTitle' to show injected count in menu entry.
+
+wrappers.setTitle = function (details){ 
+     
+    if (chrome.browserAction.setTitle !== undefined) {
+        chrome.browserAction.setTitle(details); 
+    }
+}; 


### PR DESCRIPTION
In Firefox Android, browser action shows up as menu entry (instead of icon as in Desktop version)
Changes committed below will display per-page injected count in menu entry.

Attaching screenshot. 

![screenshot_20180602-193039](https://user-images.githubusercontent.com/6957430/40877270-5d4386ac-666d-11e8-8c5f-49859b0fe56a.png)
